### PR TITLE
completed the lobby logic #22

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,3 @@
 ENVIRONMENT=development
 CSRF_AUTH_KEY=0123456789abcdef0123456789abcdef
+ALLOWED_ORIGINS=http://localhost:4200

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -6,11 +6,13 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/gorilla/csrf v1.7.2
 	github.com/gorilla/mux v1.8.1
+	github.com/gorilla/securecookie v1.1.2
 	github.com/joho/godotenv v1.5.1
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/rs/cors v1.11.1
 	golang.org/x/crypto v0.49.0
+	golang.org/x/net v0.51.0
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.31.1
 )
@@ -21,13 +23,11 @@ require (
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.33.0 // indirect
-	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect

--- a/backend/pkg/api/router_test.go
+++ b/backend/pkg/api/router_test.go
@@ -153,7 +153,11 @@ var _ = Describe("Router", func() {
 			reqWithAuth.AddCookie(sessionCookie())
 			recWithAuth := httptest.NewRecorder()
 			router.ServeHTTP(recWithAuth, reqWithAuth)
-			Expect(recWithAuth.Code).To(Equal(http.StatusNotImplemented), req.target)
+			expectedStatus := http.StatusNotImplemented
+			if req.target == "/ws" {
+				expectedStatus = http.StatusBadRequest
+			}
+			Expect(recWithAuth.Code).To(Equal(expectedStatus), req.target)
 		}
 	})
 

--- a/backend/pkg/api/ws_handler.go
+++ b/backend/pkg/api/ws_handler.go
@@ -1,9 +1,109 @@
 package api
 
-import "net/http"
+import (
+	"encoding/json"
+	"net/http"
 
-// WebSocketHandler is a protected placeholder for the authenticated websocket handshake flow.
+	"github.com/SE-RoyalFlush/Poker/backend/pkg/auth"
+	"github.com/SE-RoyalFlush/Poker/backend/pkg/db"
+	"github.com/SE-RoyalFlush/Poker/backend/pkg/models"
+	"github.com/SE-RoyalFlush/Poker/backend/pkg/room"
+	"golang.org/x/net/websocket"
+)
+
+type incomingWSMessage struct {
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+// WebSocketHandler upgrades the authenticated request and manages lobby events.
 func WebSocketHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	sendError(w, "Not Implemented", "WebSocket endpoint is not implemented yet", http.StatusNotImplemented)
+	user, err := auth.AuthenticatedUserFromRequest(r)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		sendError(w, "Unauthorized", "Authentication required", http.StatusUnauthorized)
+		return
+	}
+	if _, ok := w.(http.Hijacker); !ok {
+		w.Header().Set("Content-Type", "application/json")
+		sendError(w, "Bad Request", "WebSocket upgrade is not supported", http.StatusBadRequest)
+		return
+	}
+
+	websocket.Handler(func(conn *websocket.Conn) {
+		handleWebSocketConnection(conn, user)
+	}).ServeHTTP(w, r)
+}
+
+func handleWebSocketConnection(conn *websocket.Conn, user *models.User) {
+	client := &wsClient{
+		user: user,
+		send: make(chan wsMessage, 16),
+	}
+
+	defer func() {
+		globalWSHub.leave(client)
+		close(client.send)
+		_ = conn.Close()
+	}()
+
+	go writeWebSocketMessages(conn, client.send)
+
+	for {
+		var message incomingWSMessage
+		if err := websocket.JSON.Receive(conn, &message); err != nil {
+			return
+		}
+
+		switch message.Type {
+		case messageTypeJoinRoom:
+			if err := handleJoinRoomMessage(client, message.Payload); err != nil {
+				continue
+			}
+		case room.MessageTypeToggleReady:
+			if err := globalWSHub.handleRoomMessage(client, message.Type); err != nil {
+				continue
+			}
+		}
+	}
+}
+
+func writeWebSocketMessages(conn *websocket.Conn, send <-chan wsMessage) {
+	for message := range send {
+		if err := websocket.JSON.Send(conn, message); err != nil {
+			return
+		}
+	}
+}
+
+func handleJoinRoomMessage(client *wsClient, payload json.RawMessage) error {
+	var joinPayload joinRoomPayload
+	if err := json.Unmarshal(payload, &joinPayload); err != nil {
+		return err
+	}
+
+	roomModel, err := loadRoomByCode(joinPayload.RoomCode)
+	if err != nil {
+		return err
+	}
+
+	initialMessages, err := globalWSHub.join(roomModel, client)
+	if err != nil {
+		return err
+	}
+
+	for _, message := range initialMessages {
+		client.send <- message
+	}
+
+	return nil
+}
+
+func loadRoomByCode(code string) (*models.Room, error) {
+	database, err := db.GetDB()
+	if err != nil {
+		return nil, err
+	}
+
+	return room.FindByCode(database, code)
 }

--- a/backend/pkg/api/ws_handler.go
+++ b/backend/pkg/api/ws_handler.go
@@ -2,7 +2,11 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/url"
+	"os"
+	"strings"
 
 	"github.com/SE-RoyalFlush/Poker/backend/pkg/auth"
 	"github.com/SE-RoyalFlush/Poker/backend/pkg/db"
@@ -14,6 +18,40 @@ import (
 type incomingWSMessage struct {
 	Type    string          `json:"type"`
 	Payload json.RawMessage `json:"payload"`
+}
+
+// allowedOrigins returns the list of origins permitted to open a WebSocket
+// connection. The list is read from the ALLOWED_ORIGINS environment variable
+// (comma-separated). When the variable is absent, it defaults to the local
+// Angular development server.
+func allowedOrigins() []string {
+	raw := os.Getenv("ALLOWED_ORIGINS")
+	if raw == "" {
+		return []string{"http://localhost:4200"}
+	}
+	parts := strings.Split(raw, ",")
+	origins := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			origins = append(origins, trimmed)
+		}
+	}
+	return origins
+}
+
+// isOriginAllowed reports whether the parsed WebSocket Origin is in the
+// configured allowlist.
+func isOriginAllowed(origin *url.URL) bool {
+	if origin == nil {
+		return false
+	}
+	originStr := origin.Scheme + "://" + origin.Host
+	for _, allowed := range allowedOrigins() {
+		if strings.TrimRight(allowed, "/") == originStr {
+			return true
+		}
+	}
+	return false
 }
 
 // WebSocketHandler upgrades the authenticated request and manages lobby events.
@@ -30,9 +68,22 @@ func WebSocketHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	websocket.Handler(func(conn *websocket.Conn) {
-		handleWebSocketConnection(conn, user)
-	}).ServeHTTP(w, r)
+	wsServer := websocket.Server{
+		Handler: func(conn *websocket.Conn) {
+			handleWebSocketConnection(conn, user)
+		},
+		Handshake: func(cfg *websocket.Config, req *http.Request) error {
+			origin, err := websocket.Origin(cfg, req)
+			if err != nil {
+				return fmt.Errorf("forbidden: invalid origin: %w", err)
+			}
+			if !isOriginAllowed(origin) {
+				return fmt.Errorf("forbidden: origin %q is not allowed", origin)
+			}
+			return nil
+		},
+	}
+	wsServer.ServeHTTP(w, r)
 }
 
 func handleWebSocketConnection(conn *websocket.Conn, user *models.User) {

--- a/backend/pkg/api/ws_handler_test.go
+++ b/backend/pkg/api/ws_handler_test.go
@@ -1,0 +1,317 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/SE-RoyalFlush/Poker/backend/pkg/auth"
+	"github.com/SE-RoyalFlush/Poker/backend/pkg/db"
+	"github.com/SE-RoyalFlush/Poker/backend/pkg/models"
+	"github.com/SE-RoyalFlush/Poker/backend/pkg/room"
+	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/net/websocket"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func TestWebSocketHandlerJoinToggleReadyAndDisconnect(t *testing.T) {
+	database := setupWebSocketTestDB(t)
+	resetWebSocketStateForTesting()
+
+	host := createWebSocketUser(t, database, "host-user")
+	guest := createWebSocketUser(t, database, "guest-user")
+	roomModel, err := room.Create(database, room.CreateParams{
+		Code:       "AB12CD",
+		HostUserID: host.ID,
+		MaxPlayers: 6,
+	})
+	if err != nil {
+		t.Fatalf("failed to create room: %v", err)
+	}
+
+	server := httptest.NewServer(NewRouter())
+	defer server.Close()
+
+	hostConn := dialWebSocket(t, server.URL, sessionCookieForTest(t, "host-user"))
+	defer hostConn.Close()
+	guestConn := dialWebSocket(t, server.URL, sessionCookieForTest(t, "guest-user"))
+	defer guestConn.Close()
+
+	writeWSMessage(t, hostConn, wsMessage{
+		Type:    messageTypeJoinRoom,
+		Payload: joinRoomPayload{RoomCode: roomModel.Code},
+	})
+
+	hostJoined := readWSMessage(t, hostConn)
+	if hostJoined.Type != messageTypePlayerJoined {
+		t.Fatalf("expected host join message type %q, got %q", messageTypePlayerJoined, hostJoined.Type)
+	}
+	hostPlayer := decodeRoomPlayer(t, hostJoined.Payload)
+	if hostPlayer.Username != "host-user" || !hostPlayer.IsHost || hostPlayer.IsReady {
+		t.Fatalf("unexpected host player payload: %+v", hostPlayer)
+	}
+
+	writeWSMessage(t, guestConn, wsMessage{
+		Type:    messageTypeJoinRoom,
+		Payload: joinRoomPayload{RoomCode: roomModel.Code},
+	})
+
+	guestSeesSelf := decodeRoomPlayer(t, readWSMessage(t, guestConn).Payload)
+	guestSeesHost := decodeRoomPlayer(t, readWSMessage(t, guestConn).Payload)
+	if guestSeesSelf.ID != guest.ID && guestSeesHost.ID != guest.ID {
+		t.Fatalf("expected guest to receive their own join payload")
+	}
+	if guestSeesSelf.ID != host.ID && guestSeesHost.ID != host.ID {
+		t.Fatalf("expected guest to receive existing host payload")
+	}
+
+	hostSeesGuest := readWSMessage(t, hostConn)
+	if hostSeesGuest.Type != messageTypePlayerJoined {
+		t.Fatalf("expected host to receive guest join, got %q", hostSeesGuest.Type)
+	}
+	if decodeRoomPlayer(t, hostSeesGuest.Payload).ID != guest.ID {
+		t.Fatalf("expected host to receive guest player update")
+	}
+
+	writeWSMessage(t, guestConn, wsMessage{
+		Type:    room.MessageTypeToggleReady,
+		Payload: map[string]any{},
+	})
+
+	hostReadyUpdate := readWSMessage(t, hostConn)
+	guestReadyUpdate := readWSMessage(t, guestConn)
+	for _, update := range []wsMessage{hostReadyUpdate, guestReadyUpdate} {
+		if update.Type != room.MessageTypePlayerUpdate {
+			t.Fatalf("expected ready update type %q, got %q", room.MessageTypePlayerUpdate, update.Type)
+		}
+		player := decodeRoomPlayer(t, update.Payload)
+		if player.ID != guest.ID || !player.IsReady {
+			t.Fatalf("unexpected ready update payload: %+v", player)
+		}
+	}
+
+	if err := guestConn.Close(); err != nil {
+		t.Fatalf("failed to close guest websocket: %v", err)
+	}
+
+	hostLeftUpdate := readWSMessage(t, hostConn)
+	if hostLeftUpdate.Type != messageTypePlayerLeft {
+		t.Fatalf("expected player left message, got %q", hostLeftUpdate.Type)
+	}
+	left := decodePlayerLeft(t, hostLeftUpdate.Payload)
+	if left.ID != guest.ID {
+		t.Fatalf("expected guest ID %d in PLAYER_LEFT, got %d", guest.ID, left.ID)
+	}
+}
+
+func TestWebSocketHandlerReconnectResetsReadyState(t *testing.T) {
+	database := setupWebSocketTestDB(t)
+	resetWebSocketStateForTesting()
+
+	host := createWebSocketUser(t, database, "host-reset")
+	guest := createWebSocketUser(t, database, "guest-reset")
+	roomModel, err := room.Create(database, room.CreateParams{
+		Code:       "ZX98QP",
+		HostUserID: host.ID,
+		MaxPlayers: 6,
+	})
+	if err != nil {
+		t.Fatalf("failed to create room: %v", err)
+	}
+
+	server := httptest.NewServer(NewRouter())
+	defer server.Close()
+
+	hostConn := dialWebSocket(t, server.URL, sessionCookieForTest(t, "host-reset"))
+	defer hostConn.Close()
+	firstGuestConn := dialWebSocket(t, server.URL, sessionCookieForTest(t, "guest-reset"))
+
+	writeWSMessage(t, hostConn, wsMessage{Type: messageTypeJoinRoom, Payload: joinRoomPayload{RoomCode: roomModel.Code}})
+	_ = readWSMessage(t, hostConn)
+
+	writeWSMessage(t, firstGuestConn, wsMessage{Type: messageTypeJoinRoom, Payload: joinRoomPayload{RoomCode: roomModel.Code}})
+	_ = readWSMessage(t, firstGuestConn)
+	_ = readWSMessage(t, firstGuestConn)
+	_ = readWSMessage(t, hostConn)
+
+	writeWSMessage(t, firstGuestConn, wsMessage{Type: room.MessageTypeToggleReady, Payload: map[string]any{}})
+	_ = readWSMessage(t, firstGuestConn)
+	_ = readWSMessage(t, hostConn)
+
+	if err := firstGuestConn.Close(); err != nil {
+		t.Fatalf("failed to close first guest connection: %v", err)
+	}
+	_ = readWSMessage(t, hostConn)
+
+	secondGuestConn := dialWebSocket(t, server.URL, sessionCookieForTest(t, "guest-reset"))
+	defer secondGuestConn.Close()
+
+	writeWSMessage(t, secondGuestConn, wsMessage{Type: messageTypeJoinRoom, Payload: joinRoomPayload{RoomCode: roomModel.Code}})
+
+	first := decodeRoomPlayer(t, readWSMessage(t, secondGuestConn).Payload)
+	second := decodeRoomPlayer(t, readWSMessage(t, secondGuestConn).Payload)
+	rejoined := first
+	if rejoined.ID != guest.ID {
+		rejoined = second
+	}
+	if rejoined.ID != guest.ID {
+		t.Fatalf("expected rejoined guest payload, got %+v %+v", first, second)
+	}
+	if rejoined.IsReady {
+		t.Fatal("expected ready state to reset on reconnect")
+	}
+}
+
+func setupWebSocketTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	originalAppEnv, hadAppEnv := os.LookupEnv("APP_ENV")
+	originalGoEnv, hadGoEnv := os.LookupEnv("GO_ENV")
+	if err := os.Setenv("APP_ENV", "test"); err != nil {
+		t.Fatalf("failed to set APP_ENV: %v", err)
+	}
+	if err := os.Setenv("GO_ENV", "test"); err != nil {
+		t.Fatalf("failed to set GO_ENV: %v", err)
+	}
+
+	db.ResetForTesting()
+	t.Cleanup(func() {
+		_ = db.Close()
+		resetWebSocketStateForTesting()
+		if hadAppEnv {
+			_ = os.Setenv("APP_ENV", originalAppEnv)
+		} else {
+			_ = os.Unsetenv("APP_ENV")
+		}
+		if hadGoEnv {
+			_ = os.Setenv("GO_ENV", originalGoEnv)
+		} else {
+			_ = os.Unsetenv("GO_ENV")
+		}
+	})
+
+	cfg := &db.Config{
+		DatabasePath:    filepath.Join(t.TempDir(), "ws-test.db"),
+		MaxOpenConns:    10,
+		MaxIdleConns:    2,
+		ConnMaxLifetime: time.Minute,
+		LogLevel:        logger.Silent,
+	}
+
+	database, err := db.Connect(cfg)
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+
+	return database
+}
+
+func createWebSocketUser(t *testing.T, database *gorm.DB, username string) *models.User {
+	t.Helper()
+
+	hash, err := bcrypt.GenerateFromPassword([]byte("password123"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("failed to hash password: %v", err)
+	}
+
+	user := &models.User{
+		Username:     username,
+		PasswordHash: string(hash),
+	}
+	if err := database.Create(user).Error; err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+
+	return user
+}
+
+func sessionCookieForTest(t *testing.T, username string) *http.Cookie {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	if err := auth.SetSessionCookie(rec, username); err != nil {
+		t.Fatalf("failed to set session cookie: %v", err)
+	}
+
+	cookies := rec.Result().Cookies()
+	if len(cookies) == 0 {
+		t.Fatal("expected session cookie")
+	}
+
+	return cookies[0]
+}
+
+func dialWebSocket(t *testing.T, serverURL string, cookie *http.Cookie) *websocket.Conn {
+	t.Helper()
+
+	wsURL := "ws" + serverURL[len("http"):] + "/ws"
+	config, err := websocket.NewConfig(wsURL, "http://localhost/")
+	if err != nil {
+		t.Fatalf("failed to create websocket config: %v", err)
+	}
+	config.Header = http.Header{}
+	config.Header.Set("Cookie", cookie.String())
+
+	conn, err := websocket.DialConfig(config)
+	if err != nil {
+		t.Fatalf("failed to dial websocket: %v", err)
+	}
+
+	return conn
+}
+
+func writeWSMessage(t *testing.T, conn *websocket.Conn, message wsMessage) {
+	t.Helper()
+
+	if err := websocket.JSON.Send(conn, message); err != nil {
+		t.Fatalf("failed to send websocket message: %v", err)
+	}
+}
+
+func readWSMessage(t *testing.T, conn *websocket.Conn) wsMessage {
+	t.Helper()
+
+	if err := conn.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("failed to set websocket deadline: %v", err)
+	}
+
+	var message wsMessage
+	if err := websocket.JSON.Receive(conn, &message); err != nil {
+		t.Fatalf("failed to read websocket message: %v", err)
+	}
+
+	return message
+}
+
+func decodeRoomPlayer(t *testing.T, payload interface{}) room.Player {
+	t.Helper()
+
+	payloadMap, ok := payload.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map payload, got %T", payload)
+	}
+
+	return room.Player{
+		ID:       uint(payloadMap["id"].(float64)),
+		Username: payloadMap["username"].(string),
+		IsHost:   payloadMap["isHost"].(bool),
+		IsReady:  payloadMap["isReady"].(bool),
+	}
+}
+
+func decodePlayerLeft(t *testing.T, payload interface{}) playerLeftPayload {
+	t.Helper()
+
+	payloadMap, ok := payload.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map payload, got %T", payload)
+	}
+
+	return playerLeftPayload{
+		ID: uint(payloadMap["id"].(float64)),
+	}
+}

--- a/backend/pkg/api/ws_handler_test.go
+++ b/backend/pkg/api/ws_handler_test.go
@@ -249,7 +249,7 @@ func dialWebSocket(t *testing.T, serverURL string, cookie *http.Cookie) *websock
 	t.Helper()
 
 	wsURL := "ws" + serverURL[len("http"):] + "/ws"
-	config, err := websocket.NewConfig(wsURL, "http://localhost/")
+	config, err := websocket.NewConfig(wsURL, "http://localhost:4200")
 	if err != nil {
 		t.Fatalf("failed to create websocket config: %v", err)
 	}

--- a/backend/pkg/api/ws_runtime.go
+++ b/backend/pkg/api/ws_runtime.go
@@ -72,7 +72,6 @@ func (h *wsHub) join(roomModel *models.Room, client *wsClient) ([]wsMessage, err
 	}
 
 	h.mu.Lock()
-	defer h.mu.Unlock()
 
 	wsRoomState, ok := h.rooms[roomModel.Code]
 	if !ok {
@@ -108,7 +107,14 @@ func (h *wsHub) join(roomModel *models.Room, client *wsClient) ([]wsMessage, err
 		Payload: player,
 	}
 
+	recipients := make([]*wsClient, 0, len(wsRoomState.clients))
 	for member := range wsRoomState.clients {
+		recipients = append(recipients, member)
+	}
+
+	h.mu.Unlock()
+
+	for _, member := range recipients {
 		member.send <- broadcast
 	}
 
@@ -129,11 +135,11 @@ func (h *wsHub) leave(client *wsClient) {
 	}
 
 	h.mu.Lock()
-	defer h.mu.Unlock()
 
 	wsRoomState, ok := h.rooms[client.roomCode]
 	if !ok {
 		client.roomCode = ""
+		h.mu.Unlock()
 		return
 	}
 
@@ -147,22 +153,31 @@ func (h *wsHub) leave(client *wsClient) {
 		}
 	}
 
+	var recipients []*wsClient
+	var leftMessage wsMessage
 	if !hasActiveConnection {
 		wsRoomState.lobby.RemovePlayer(client.user.ID)
 
-		leftMessage := wsMessage{
+		leftMessage = wsMessage{
 			Type:    messageTypePlayerLeft,
 			Payload: playerLeftPayload{ID: client.user.ID},
 		}
+		recipients = make([]*wsClient, 0, len(wsRoomState.clients))
 		for member := range wsRoomState.clients {
-			member.send <- leftMessage
+			recipients = append(recipients, member)
 		}
 	}
+
 	if len(wsRoomState.clients) == 0 {
 		delete(h.rooms, client.roomCode)
 	}
 
 	client.roomCode = ""
+	h.mu.Unlock()
+
+	for _, member := range recipients {
+		member.send <- leftMessage
+	}
 }
 
 func (h *wsHub) handleRoomMessage(client *wsClient, messageType string) error {
@@ -191,8 +206,13 @@ func (h *wsHub) handleRoomMessage(client *wsClient, messageType string) error {
 	}
 
 	h.mu.RLock()
-	defer h.mu.RUnlock()
+	recipients := make([]*wsClient, 0, len(wsRoomState.clients))
 	for member := range wsRoomState.clients {
+		recipients = append(recipients, member)
+	}
+	h.mu.RUnlock()
+
+	for _, member := range recipients {
 		member.send <- message
 	}
 

--- a/backend/pkg/api/ws_runtime.go
+++ b/backend/pkg/api/ws_runtime.go
@@ -56,7 +56,14 @@ func newWSHub() *wsHub {
 var globalWSHub = newWSHub()
 
 func resetWebSocketStateForTesting() {
-	globalWSHub = newWSHub()
+	globalWSHub.reset()
+}
+
+func (h *wsHub) reset() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.rooms = make(map[string]*wsRoom)
 }
 
 func (h *wsHub) join(roomModel *models.Room, client *wsClient) ([]wsMessage, error) {

--- a/backend/pkg/api/ws_runtime.go
+++ b/backend/pkg/api/ws_runtime.go
@@ -131,16 +131,26 @@ func (h *wsHub) leave(client *wsClient) {
 	}
 
 	delete(wsRoomState.clients, client)
-	wsRoomState.lobby.RemovePlayer(client.user.ID)
 
-	leftMessage := wsMessage{
-		Type:    messageTypePlayerLeft,
-		Payload: playerLeftPayload{ID: client.user.ID},
-	}
+	hasActiveConnection := false
 	for member := range wsRoomState.clients {
-		member.send <- leftMessage
+		if member != nil && member.user.ID == client.user.ID {
+			hasActiveConnection = true
+			break
+		}
 	}
 
+	if !hasActiveConnection {
+		wsRoomState.lobby.RemovePlayer(client.user.ID)
+
+		leftMessage := wsMessage{
+			Type:    messageTypePlayerLeft,
+			Payload: playerLeftPayload{ID: client.user.ID},
+		}
+		for member := range wsRoomState.clients {
+			member.send <- leftMessage
+		}
+	}
 	if len(wsRoomState.clients) == 0 {
 		delete(h.rooms, client.roomCode)
 	}

--- a/backend/pkg/api/ws_runtime.go
+++ b/backend/pkg/api/ws_runtime.go
@@ -1,0 +1,183 @@
+package api
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/SE-RoyalFlush/Poker/backend/pkg/models"
+	"github.com/SE-RoyalFlush/Poker/backend/pkg/room"
+)
+
+const (
+	messageTypeJoinRoom     = "JOIN_ROOM"
+	messageTypePlayerJoined = "PLAYER_JOINED"
+	messageTypePlayerLeft   = "PLAYER_LEFT"
+)
+
+var (
+	errMissingRoomCode = errors.New("missing room code")
+)
+
+type wsMessage struct {
+	Type    string      `json:"type"`
+	Payload interface{} `json:"payload"`
+}
+
+type joinRoomPayload struct {
+	RoomCode string `json:"roomCode"`
+}
+
+type playerLeftPayload struct {
+	ID uint `json:"id"`
+}
+
+type wsClient struct {
+	user     *models.User
+	send     chan wsMessage
+	roomCode string
+}
+
+type wsRoom struct {
+	lobby   *room.Lobby
+	clients map[*wsClient]struct{}
+}
+
+type wsHub struct {
+	mu    sync.RWMutex
+	rooms map[string]*wsRoom
+}
+
+func newWSHub() *wsHub {
+	return &wsHub{
+		rooms: make(map[string]*wsRoom),
+	}
+}
+
+var globalWSHub = newWSHub()
+
+func resetWebSocketStateForTesting() {
+	globalWSHub = newWSHub()
+}
+
+func (h *wsHub) join(roomModel *models.Room, client *wsClient) ([]wsMessage, error) {
+	if roomModel == nil {
+		return nil, errMissingRoomCode
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	wsRoomState, ok := h.rooms[roomModel.Code]
+	if !ok {
+		wsRoomState = &wsRoom{
+			lobby:   room.NewLobby(),
+			clients: make(map[*wsClient]struct{}),
+		}
+		h.rooms[roomModel.Code] = wsRoomState
+	}
+
+	client.roomCode = roomModel.Code
+	wsRoomState.clients[client] = struct{}{}
+
+	player := wsRoomState.lobby.JoinPlayer(room.Player{
+		ID:       client.user.ID,
+		Username: client.user.Username,
+		IsHost:   roomModel.HostUserID == client.user.ID,
+	})
+
+	existingPlayers := make([]room.Player, 0, len(wsRoomState.clients))
+	for existingClient := range wsRoomState.clients {
+		if existingClient == client {
+			continue
+		}
+		existingPlayer, ok := wsRoomState.lobby.Player(existingClient.user.ID)
+		if ok {
+			existingPlayers = append(existingPlayers, existingPlayer)
+		}
+	}
+
+	broadcast := wsMessage{
+		Type:    messageTypePlayerJoined,
+		Payload: player,
+	}
+
+	for member := range wsRoomState.clients {
+		member.send <- broadcast
+	}
+
+	initialMessages := make([]wsMessage, 0, len(existingPlayers))
+	for _, existingPlayer := range existingPlayers {
+		initialMessages = append(initialMessages, wsMessage{
+			Type:    messageTypePlayerJoined,
+			Payload: existingPlayer,
+		})
+	}
+
+	return initialMessages, nil
+}
+
+func (h *wsHub) leave(client *wsClient) {
+	if client == nil || client.roomCode == "" {
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	wsRoomState, ok := h.rooms[client.roomCode]
+	if !ok {
+		client.roomCode = ""
+		return
+	}
+
+	delete(wsRoomState.clients, client)
+	wsRoomState.lobby.RemovePlayer(client.user.ID)
+
+	leftMessage := wsMessage{
+		Type:    messageTypePlayerLeft,
+		Payload: playerLeftPayload{ID: client.user.ID},
+	}
+	for member := range wsRoomState.clients {
+		member.send <- leftMessage
+	}
+
+	if len(wsRoomState.clients) == 0 {
+		delete(h.rooms, client.roomCode)
+	}
+
+	client.roomCode = ""
+}
+
+func (h *wsHub) handleRoomMessage(client *wsClient, messageType string) error {
+	if client == nil || client.roomCode == "" {
+		return nil
+	}
+
+	h.mu.RLock()
+	wsRoomState, ok := h.rooms[client.roomCode]
+	h.mu.RUnlock()
+	if !ok {
+		return nil
+	}
+
+	event, err := wsRoomState.lobby.HandleMessage(messageType, client.user.ID)
+	if err != nil {
+		return err
+	}
+	if event.Type == "" {
+		return nil
+	}
+
+	message := wsMessage{
+		Type:    event.Type,
+		Payload: event.Payload,
+	}
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for member := range wsRoomState.clients {
+		member.send <- message
+	}
+
+	return nil
+}

--- a/backend/pkg/api/ws_runtime.go
+++ b/backend/pkg/api/ws_runtime.go
@@ -175,8 +175,10 @@ func (h *wsHub) leave(client *wsClient) {
 	client.roomCode = ""
 	h.mu.Unlock()
 
-	for _, member := range recipients {
-		member.send <- leftMessage
+	if !hasActiveConnection {
+		for _, member := range recipients {
+			member.send <- leftMessage
+		}
 	}
 }
 

--- a/backend/pkg/room/lobby.go
+++ b/backend/pkg/room/lobby.go
@@ -1,0 +1,117 @@
+package room
+
+import (
+	"errors"
+	"sync"
+)
+
+var (
+	ErrPlayerNotFound = errors.New("player not found")
+)
+
+const (
+	MessageTypeToggleReady  = "TOGGLE_READY"
+	MessageTypePlayerUpdate = "PLAYER_UPDATE"
+)
+
+// Player represents the public player state shared with room participants.
+type Player struct {
+	ID       uint   `json:"id"`
+	Username string `json:"username"`
+	IsHost   bool   `json:"isHost"`
+	IsReady  bool   `json:"isReady"`
+}
+
+// Event represents a websocket-style room event envelope.
+type Event struct {
+	Type    string `json:"type"`
+	Payload Player `json:"payload"`
+}
+
+// Lobby stores the in-memory player state for a room.
+type Lobby struct {
+	mu      sync.RWMutex
+	players map[uint]Player
+}
+
+// NewLobby creates an empty in-memory room lobby state.
+func NewLobby() *Lobby {
+	return &Lobby{
+		players: make(map[uint]Player),
+	}
+}
+
+// JoinPlayer adds a player to the lobby or resets their ready state on rejoin.
+func (l *Lobby) JoinPlayer(player Player) Player {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	player.IsReady = false
+	l.players[player.ID] = player
+
+	return player
+}
+
+// RemovePlayer removes a player from the lobby state.
+func (l *Lobby) RemovePlayer(playerID uint) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	delete(l.players, playerID)
+}
+
+// ToggleReady flips a player's ready state and returns the event to broadcast.
+func (l *Lobby) ToggleReady(playerID uint) (Event, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	player, ok := l.players[playerID]
+	if !ok {
+		return Event{}, ErrPlayerNotFound
+	}
+
+	player.IsReady = !player.IsReady
+	l.players[playerID] = player
+
+	return Event{
+		Type:    MessageTypePlayerUpdate,
+		Payload: player,
+	}, nil
+}
+
+// HandleMessage applies supported room messages and returns any event to broadcast.
+func (l *Lobby) HandleMessage(messageType string, playerID uint) (Event, error) {
+	switch messageType {
+	case MessageTypeToggleReady:
+		return l.ToggleReady(playerID)
+	default:
+		return Event{}, nil
+	}
+}
+
+// Player returns the current player state.
+func (l *Lobby) Player(playerID uint) (Player, bool) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	player, ok := l.players[playerID]
+	return player, ok
+}
+
+// AllReady reports whether every tracked player is marked ready.
+func (l *Lobby) AllReady() bool {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	if len(l.players) == 0 {
+		return false
+	}
+
+	for _, player := range l.players {
+		if !player.IsReady {
+			return false
+		}
+	}
+
+	return true
+}

--- a/backend/pkg/room/lobby_test.go
+++ b/backend/pkg/room/lobby_test.go
@@ -1,0 +1,106 @@
+package room_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/SE-RoyalFlush/Poker/backend/pkg/room"
+)
+
+func TestLobbyToggleReadyBroadcastsPlayerUpdate(t *testing.T) {
+	lobby := room.NewLobby()
+	player := lobby.JoinPlayer(room.Player{
+		ID:       7,
+		Username: "alice",
+		IsHost:   true,
+	})
+
+	if player.IsReady {
+		t.Fatal("expected joined player to start not ready")
+	}
+
+	event, err := lobby.HandleMessage(room.MessageTypeToggleReady, player.ID)
+	if err != nil {
+		t.Fatalf("HandleMessage returned error: %v", err)
+	}
+
+	if event.Type != room.MessageTypePlayerUpdate {
+		t.Fatalf("expected event type %q, got %q", room.MessageTypePlayerUpdate, event.Type)
+	}
+	if event.Payload.ID != player.ID {
+		t.Fatalf("expected payload player ID %d, got %d", player.ID, event.Payload.ID)
+	}
+	if !event.Payload.IsReady {
+		t.Fatal("expected payload to mark player ready")
+	}
+
+	updated, ok := lobby.Player(player.ID)
+	if !ok {
+		t.Fatalf("expected player %d to remain in lobby", player.ID)
+	}
+	if !updated.IsReady {
+		t.Fatal("expected ready state to persist in lobby")
+	}
+}
+
+func TestLobbyJoinPlayerResetsReadyStateOnReconnect(t *testing.T) {
+	lobby := room.NewLobby()
+	player := lobby.JoinPlayer(room.Player{
+		ID:       9,
+		Username: "bob",
+	})
+
+	if _, err := lobby.ToggleReady(player.ID); err != nil {
+		t.Fatalf("ToggleReady returned error: %v", err)
+	}
+
+	rejoined := lobby.JoinPlayer(room.Player{
+		ID:       player.ID,
+		Username: player.Username,
+	})
+
+	if rejoined.IsReady {
+		t.Fatal("expected rejoined player ready state to reset")
+	}
+
+	stored, ok := lobby.Player(player.ID)
+	if !ok {
+		t.Fatalf("expected player %d after rejoin", player.ID)
+	}
+	if stored.IsReady {
+		t.Fatal("expected stored player ready state to be reset on rejoin")
+	}
+}
+
+func TestLobbyToggleReadyReturnsErrorForUnknownPlayer(t *testing.T) {
+	lobby := room.NewLobby()
+
+	_, err := lobby.ToggleReady(404)
+	if !errors.Is(err, room.ErrPlayerNotFound) {
+		t.Fatalf("expected ErrPlayerNotFound, got %v", err)
+	}
+}
+
+func TestLobbyAllReady(t *testing.T) {
+	lobby := room.NewLobby()
+	lobby.JoinPlayer(room.Player{ID: 1, Username: "alice"})
+	lobby.JoinPlayer(room.Player{ID: 2, Username: "bob"})
+
+	if lobby.AllReady() {
+		t.Fatal("expected AllReady to be false before toggles")
+	}
+
+	if _, err := lobby.ToggleReady(1); err != nil {
+		t.Fatalf("ToggleReady returned error: %v", err)
+	}
+	if lobby.AllReady() {
+		t.Fatal("expected AllReady to remain false until all players are ready")
+	}
+
+	if _, err := lobby.ToggleReady(2); err != nil {
+		t.Fatalf("ToggleReady returned error: %v", err)
+	}
+	if !lobby.AllReady() {
+		t.Fatal("expected AllReady to be true once all players are ready")
+	}
+}


### PR DESCRIPTION
Implements issue #22 by adding backend lobby ready-state handling over the authenticated websocket flow. Players can now join a room, toggle ready status with TOGGLE_READY, receive PLAYER_UPDATE broadcasts, and have ready state reset on reconnect.

What Changed

Replaced the /ws placeholder with a real authenticated websocket handler.
Added an in-memory room hub to manage:
room membership
PLAYER_JOINED broadcasts
PLAYER_LEFT broadcasts
TOGGLE_READY handling
PLAYER_UPDATE broadcasts
Added backend player lobby state with IsReady.
Added an AllReady() helper as the stub foundation for future game-start logic.
Updated router expectations to reflect the real websocket upgrade behavior.
Behavior

Authenticated clients connect to /ws.
Clients send JOIN_ROOM with { roomCode } to join a room.
Clients send TOGGLE_READY to flip their ready state.
All room members receive PLAYER_UPDATE with the updated player payload.
Disconnecting removes the player from the room and broadcasts PLAYER_LEFT.
Reconnecting resets IsReady to false.
Testing

Added coverage for:

ready toggle producing PLAYER_UPDATE
ready-state persistence in room state
reconnect resetting ready state
unknown-player toggle handling
AllReady() behavior
websocket integration flow for join, toggle ready, disconnect, and reconnect reset
Verification

env GOCACHE=/tmp/go-cache go test ./pkg/api/...
env GOCACHE=/tmp/go-cache go test ./...
Both passed.

#22 