### PR TITLE
implemented Lobby Logic & Broadcasting logic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+- [Backend: Lobby Logic & Broadcasting (Issue #18)](https://github.com/SE-RoyalFlush/Poker/issues/18)
+    - Implemented room-scoped WebSocket lobby state in `backend/pkg/api/ws_runtime.go` with per-room client membership and broadcasts
+    - Added `JOIN_ROOM`, `LEAVE_ROOM`, `ROOM_STATE`, `PLAYER_JOINED`, and `PLAYER_LEFT` message handling for lobby presence updates
+    - `JOIN_ROOM` now returns a room snapshot to the joining client and broadcasts `PLAYER_JOINED` only to the other clients in that room
+    - Disconnects and explicit `LEAVE_ROOM` events now remove the client from the room and notify remaining members with `PLAYER_LEFT`
+    - Added backend tests covering room isolation, join broadcast semantics, explicit leave, and reconnect-ready-state reset
 - [Frontend: Lobby Component & State (Issue #21)](https://github.com/SE-RoyalFlush/Poker/issues/21)
     - Implemented `Lobby` at `frontend/src/app/pages/lobby/lobby.ts` — reads `roomCode` from `?code=` query param, connects via `WebSocketService`, sends `JOIN_ROOM` on open, handles `PLAYER_JOINED` (with `_.uniqBy` deduplication by id) and `PLAYER_LEFT` messages, sorts players host-first via `_.orderBy`
     - Added `Player` interface (`{ id, username, isHost }`) at `frontend/src/app/core/models/player.model.ts` and exported from models barrel

--- a/backend/pkg/api/ws_handler.go
+++ b/backend/pkg/api/ws_handler.go
@@ -111,6 +111,8 @@ func handleWebSocketConnection(conn *websocket.Conn, user *models.User) {
 			if err := handleJoinRoomMessage(client, message.Payload); err != nil {
 				continue
 			}
+		case messageTypeLeaveRoom:
+			globalWSHub.leave(client)
 		case room.MessageTypeToggleReady:
 			if err := globalWSHub.handleRoomMessage(client, message.Type); err != nil {
 				continue
@@ -136,6 +138,10 @@ func handleJoinRoomMessage(client *wsClient, payload json.RawMessage) error {
 	roomModel, err := loadRoomByCode(joinPayload.RoomCode)
 	if err != nil {
 		return err
+	}
+
+	if client.roomCode != "" && client.roomCode != roomModel.Code {
+		globalWSHub.leave(client)
 	}
 
 	initialMessages, err := globalWSHub.join(roomModel, client)

--- a/backend/pkg/api/ws_handler_test.go
+++ b/backend/pkg/api/ws_handler_test.go
@@ -46,13 +46,16 @@ func TestWebSocketHandlerJoinToggleReadyAndDisconnect(t *testing.T) {
 		Payload: joinRoomPayload{RoomCode: roomModel.Code},
 	})
 
-	hostJoined := readWSMessage(t, hostConn)
-	if hostJoined.Type != messageTypePlayerJoined {
-		t.Fatalf("expected host join message type %q, got %q", messageTypePlayerJoined, hostJoined.Type)
+	hostSnapshot := readWSMessage(t, hostConn)
+	if hostSnapshot.Type != messageTypeRoomState {
+		t.Fatalf("expected host snapshot message type %q, got %q", messageTypeRoomState, hostSnapshot.Type)
 	}
-	hostPlayer := decodeRoomPlayer(t, hostJoined.Payload)
-	if hostPlayer.Username != "host-user" || !hostPlayer.IsHost || hostPlayer.IsReady {
-		t.Fatalf("unexpected host player payload: %+v", hostPlayer)
+	hostPlayers := decodeRoomState(t, hostSnapshot.Payload)
+	if len(hostPlayers) != 1 {
+		t.Fatalf("expected snapshot with 1 player, got %d", len(hostPlayers))
+	}
+	if hostPlayers[0].Username != "host-user" || !hostPlayers[0].IsHost || hostPlayers[0].IsReady {
+		t.Fatalf("unexpected host player payload: %+v", hostPlayers[0])
 	}
 
 	writeWSMessage(t, guestConn, wsMessage{
@@ -60,13 +63,19 @@ func TestWebSocketHandlerJoinToggleReadyAndDisconnect(t *testing.T) {
 		Payload: joinRoomPayload{RoomCode: roomModel.Code},
 	})
 
-	guestSeesSelf := decodeRoomPlayer(t, readWSMessage(t, guestConn).Payload)
-	guestSeesHost := decodeRoomPlayer(t, readWSMessage(t, guestConn).Payload)
-	if guestSeesSelf.ID != guest.ID && guestSeesHost.ID != guest.ID {
-		t.Fatalf("expected guest to receive their own join payload")
+	guestSnapshot := readWSMessage(t, guestConn)
+	if guestSnapshot.Type != messageTypeRoomState {
+		t.Fatalf("expected guest snapshot message type %q, got %q", messageTypeRoomState, guestSnapshot.Type)
 	}
-	if guestSeesSelf.ID != host.ID && guestSeesHost.ID != host.ID {
-		t.Fatalf("expected guest to receive existing host payload")
+	guestPlayers := decodeRoomState(t, guestSnapshot.Payload)
+	if len(guestPlayers) != 2 {
+		t.Fatalf("expected snapshot with 2 players, got %d", len(guestPlayers))
+	}
+	if !containsPlayer(guestPlayers, guest.ID) {
+		t.Fatalf("expected guest snapshot to include guest ID %d", guest.ID)
+	}
+	if !containsPlayer(guestPlayers, host.ID) {
+		t.Fatalf("expected guest snapshot to include host ID %d", host.ID)
 	}
 
 	hostSeesGuest := readWSMessage(t, hostConn)
@@ -78,25 +87,9 @@ func TestWebSocketHandlerJoinToggleReadyAndDisconnect(t *testing.T) {
 	}
 
 	writeWSMessage(t, guestConn, wsMessage{
-		Type:    room.MessageTypeToggleReady,
+		Type:    messageTypeLeaveRoom,
 		Payload: map[string]any{},
 	})
-
-	hostReadyUpdate := readWSMessage(t, hostConn)
-	guestReadyUpdate := readWSMessage(t, guestConn)
-	for _, update := range []wsMessage{hostReadyUpdate, guestReadyUpdate} {
-		if update.Type != room.MessageTypePlayerUpdate {
-			t.Fatalf("expected ready update type %q, got %q", room.MessageTypePlayerUpdate, update.Type)
-		}
-		player := decodeRoomPlayer(t, update.Payload)
-		if player.ID != guest.ID || !player.IsReady {
-			t.Fatalf("unexpected ready update payload: %+v", player)
-		}
-	}
-
-	if err := guestConn.Close(); err != nil {
-		t.Fatalf("failed to close guest websocket: %v", err)
-	}
 
 	hostLeftUpdate := readWSMessage(t, hostConn)
 	if hostLeftUpdate.Type != messageTypePlayerLeft {
@@ -106,6 +99,8 @@ func TestWebSocketHandlerJoinToggleReadyAndDisconnect(t *testing.T) {
 	if left.ID != guest.ID {
 		t.Fatalf("expected guest ID %d in PLAYER_LEFT, got %d", guest.ID, left.ID)
 	}
+
+	expectNoWSMessage(t, guestConn)
 }
 
 func TestWebSocketHandlerReconnectResetsReadyState(t *testing.T) {
@@ -135,7 +130,6 @@ func TestWebSocketHandlerReconnectResetsReadyState(t *testing.T) {
 
 	writeWSMessage(t, firstGuestConn, wsMessage{Type: messageTypeJoinRoom, Payload: joinRoomPayload{RoomCode: roomModel.Code}})
 	_ = readWSMessage(t, firstGuestConn)
-	_ = readWSMessage(t, firstGuestConn)
 	_ = readWSMessage(t, hostConn)
 
 	writeWSMessage(t, firstGuestConn, wsMessage{Type: room.MessageTypeToggleReady, Payload: map[string]any{}})
@@ -152,18 +146,75 @@ func TestWebSocketHandlerReconnectResetsReadyState(t *testing.T) {
 
 	writeWSMessage(t, secondGuestConn, wsMessage{Type: messageTypeJoinRoom, Payload: joinRoomPayload{RoomCode: roomModel.Code}})
 
-	first := decodeRoomPlayer(t, readWSMessage(t, secondGuestConn).Payload)
-	second := decodeRoomPlayer(t, readWSMessage(t, secondGuestConn).Payload)
-	rejoined := first
-	if rejoined.ID != guest.ID {
-		rejoined = second
+	snapshot := readWSMessage(t, secondGuestConn)
+	if snapshot.Type != messageTypeRoomState {
+		t.Fatalf("expected rejoin snapshot type %q, got %q", messageTypeRoomState, snapshot.Type)
 	}
-	if rejoined.ID != guest.ID {
-		t.Fatalf("expected rejoined guest payload, got %+v %+v", first, second)
+	players := decodeRoomState(t, snapshot.Payload)
+	rejoined, ok := findPlayer(players, guest.ID)
+	if !ok {
+		t.Fatalf("expected rejoined guest payload in snapshot, got %+v", players)
 	}
 	if rejoined.IsReady {
 		t.Fatal("expected ready state to reset on reconnect")
 	}
+}
+
+func TestWebSocketHandlerIsolatesRoomsAndBroadcastsWithinRoomOnly(t *testing.T) {
+	database := setupWebSocketTestDB(t)
+	resetWebSocketStateForTesting()
+
+	hostRoomOne := createWebSocketUser(t, database, "host-room-one")
+	hostRoomTwo := createWebSocketUser(t, database, "host-room-two")
+	guestRoomOne := createWebSocketUser(t, database, "guest-room-one")
+
+	roomOne, err := room.Create(database, room.CreateParams{
+		Code:       "ROOM11",
+		HostUserID: hostRoomOne.ID,
+		MaxPlayers: 6,
+	})
+	if err != nil {
+		t.Fatalf("failed to create room one: %v", err)
+	}
+	roomTwo, err := room.Create(database, room.CreateParams{
+		Code:       "ROOM22",
+		HostUserID: hostRoomTwo.ID,
+		MaxPlayers: 6,
+	})
+	if err != nil {
+		t.Fatalf("failed to create room two: %v", err)
+	}
+
+	server := httptest.NewServer(NewRouter())
+	defer server.Close()
+
+	roomOneHostConn := dialWebSocket(t, server.URL, sessionCookieForTest(t, "host-room-one"))
+	defer roomOneHostConn.Close()
+	roomTwoHostConn := dialWebSocket(t, server.URL, sessionCookieForTest(t, "host-room-two"))
+	defer roomTwoHostConn.Close()
+	roomOneGuestConn := dialWebSocket(t, server.URL, sessionCookieForTest(t, "guest-room-one"))
+	defer roomOneGuestConn.Close()
+
+	writeWSMessage(t, roomOneHostConn, wsMessage{Type: messageTypeJoinRoom, Payload: joinRoomPayload{RoomCode: roomOne.Code}})
+	writeWSMessage(t, roomTwoHostConn, wsMessage{Type: messageTypeJoinRoom, Payload: joinRoomPayload{RoomCode: roomTwo.Code}})
+	_ = readWSMessage(t, roomOneHostConn)
+	_ = readWSMessage(t, roomTwoHostConn)
+
+	writeWSMessage(t, roomOneGuestConn, wsMessage{Type: messageTypeJoinRoom, Payload: joinRoomPayload{RoomCode: roomOne.Code}})
+	guestSnapshot := readWSMessage(t, roomOneGuestConn)
+	if guestSnapshot.Type != messageTypeRoomState {
+		t.Fatalf("expected guest snapshot type %q, got %q", messageTypeRoomState, guestSnapshot.Type)
+	}
+
+	hostOneEvent := readWSMessage(t, roomOneHostConn)
+	if hostOneEvent.Type != messageTypePlayerJoined {
+		t.Fatalf("expected room one host to receive %q, got %q", messageTypePlayerJoined, hostOneEvent.Type)
+	}
+	if decodeRoomPlayer(t, hostOneEvent.Payload).ID != guestRoomOne.ID {
+		t.Fatalf("expected room one broadcast for guest ID %d", guestRoomOne.ID)
+	}
+
+	expectNoWSMessage(t, roomTwoHostConn)
 }
 
 func setupWebSocketTestDB(t *testing.T) *gorm.DB {
@@ -287,6 +338,22 @@ func readWSMessage(t *testing.T, conn *websocket.Conn) wsMessage {
 	return message
 }
 
+func expectNoWSMessage(t *testing.T, conn *websocket.Conn) {
+	t.Helper()
+
+	if err := conn.SetDeadline(time.Now().Add(200 * time.Millisecond)); err != nil {
+		t.Fatalf("failed to set websocket deadline: %v", err)
+	}
+	defer func() {
+		_ = conn.SetDeadline(time.Time{})
+	}()
+
+	var message wsMessage
+	if err := websocket.JSON.Receive(conn, &message); err == nil {
+		t.Fatalf("expected no websocket message, got %+v", message)
+	}
+}
+
 func decodeRoomPlayer(t *testing.T, payload interface{}) room.Player {
 	t.Helper()
 
@@ -314,4 +381,49 @@ func decodePlayerLeft(t *testing.T, payload interface{}) playerLeftPayload {
 	return playerLeftPayload{
 		ID: uint(payloadMap["id"].(float64)),
 	}
+}
+
+func decodeRoomState(t *testing.T, payload interface{}) []room.Player {
+	t.Helper()
+
+	payloadMap, ok := payload.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map payload, got %T", payload)
+	}
+
+	rawPlayers, ok := payloadMap["players"].([]interface{})
+	if !ok {
+		t.Fatalf("expected players array, got %T", payloadMap["players"])
+	}
+
+	players := make([]room.Player, 0, len(rawPlayers))
+	for _, rawPlayer := range rawPlayers {
+		playerMap, ok := rawPlayer.(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected player map, got %T", rawPlayer)
+		}
+		players = append(players, room.Player{
+			ID:       uint(playerMap["id"].(float64)),
+			Username: playerMap["username"].(string),
+			IsHost:   playerMap["isHost"].(bool),
+			IsReady:  playerMap["isReady"].(bool),
+		})
+	}
+
+	return players
+}
+
+func containsPlayer(players []room.Player, playerID uint) bool {
+	_, ok := findPlayer(players, playerID)
+	return ok
+}
+
+func findPlayer(players []room.Player, playerID uint) (room.Player, bool) {
+	for _, player := range players {
+		if player.ID == playerID {
+			return player, true
+		}
+	}
+
+	return room.Player{}, false
 }

--- a/backend/pkg/api/ws_handler_test.go
+++ b/backend/pkg/api/ws_handler_test.go
@@ -1,6 +1,9 @@
 package api
 
 import (
+	"errors"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -341,7 +344,7 @@ func readWSMessage(t *testing.T, conn *websocket.Conn) wsMessage {
 func expectNoWSMessage(t *testing.T, conn *websocket.Conn) {
 	t.Helper()
 
-	if err := conn.SetDeadline(time.Now().Add(200 * time.Millisecond)); err != nil {
+	if err := conn.SetDeadline(time.Now().Add(500 * time.Millisecond)); err != nil {
 		t.Fatalf("failed to set websocket deadline: %v", err)
 	}
 	defer func() {
@@ -351,7 +354,30 @@ func expectNoWSMessage(t *testing.T, conn *websocket.Conn) {
 	var message wsMessage
 	if err := websocket.JSON.Receive(conn, &message); err == nil {
 		t.Fatalf("expected no websocket message, got %+v", message)
+	} else if !isTimeoutError(err) {
+		t.Fatalf("expected timeout while waiting for no websocket message, got %v", err)
 	}
+}
+
+func isTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	if errors.Is(err, io.EOF) {
+		return false
+	}
+
+	return false
 }
 
 func decodeRoomPlayer(t *testing.T, payload interface{}) room.Player {

--- a/backend/pkg/api/ws_runtime.go
+++ b/backend/pkg/api/ws_runtime.go
@@ -60,6 +60,18 @@ func newWSHub() *wsHub {
 	}
 }
 
+// safeSend delivers msg to ch without panicking if ch has already been closed.
+// It returns false when the channel was closed before the send could complete.
+func safeSend(ch chan<- wsMessage, msg wsMessage) (ok bool) {
+	defer func() {
+		if recover() != nil {
+			ok = false
+		}
+	}()
+	ch <- msg
+	return true
+}
+
 var globalWSHub = newWSHub()
 
 func resetWebSocketStateForTesting() {
@@ -122,7 +134,7 @@ func (h *wsHub) join(roomModel *models.Room, client *wsClient) ([]wsMessage, err
 	h.mu.Unlock()
 
 	for _, member := range recipients {
-		member.send <- broadcast
+		safeSend(member.send, broadcast)
 	}
 
 	return []wsMessage{snapshot}, nil
@@ -176,7 +188,7 @@ func (h *wsHub) leave(client *wsClient) {
 
 	if !hasActiveConnection {
 		for _, member := range recipients {
-			member.send <- leftMessage
+			safeSend(member.send, leftMessage)
 		}
 	}
 }
@@ -214,7 +226,7 @@ func (h *wsHub) handleRoomMessage(client *wsClient, messageType string) error {
 	h.mu.RUnlock()
 
 	for _, member := range recipients {
-		member.send <- message
+		safeSend(member.send, message)
 	}
 
 	return nil

--- a/backend/pkg/api/ws_runtime.go
+++ b/backend/pkg/api/ws_runtime.go
@@ -60,14 +60,14 @@ func newWSHub() *wsHub {
 	}
 }
 
-// safeSend delivers msg to ch without panicking if ch has already been closed.
-// It returns false when the channel was closed before the send could complete.
+// safeSend prevents a racing channel close from crashing the websocket hub.
 func safeSend(ch chan<- wsMessage, msg wsMessage) (ok bool) {
 	defer func() {
 		if recover() != nil {
 			ok = false
 		}
 	}()
+
 	ch <- msg
 	return true
 }

--- a/backend/pkg/api/ws_runtime.go
+++ b/backend/pkg/api/ws_runtime.go
@@ -10,6 +10,8 @@ import (
 
 const (
 	messageTypeJoinRoom     = "JOIN_ROOM"
+	messageTypeLeaveRoom    = "LEAVE_ROOM"
+	messageTypeRoomState    = "ROOM_STATE"
 	messageTypePlayerJoined = "PLAYER_JOINED"
 	messageTypePlayerLeft   = "PLAYER_LEFT"
 )
@@ -29,6 +31,11 @@ type joinRoomPayload struct {
 
 type playerLeftPayload struct {
 	ID uint `json:"id"`
+}
+
+type roomStatePayload struct {
+	RoomCode string        `json:"roomCode"`
+	Players  []room.Player `json:"players"`
 }
 
 type wsClient struct {
@@ -91,17 +98,6 @@ func (h *wsHub) join(roomModel *models.Room, client *wsClient) ([]wsMessage, err
 		IsHost:   roomModel.HostUserID == client.user.ID,
 	})
 
-	existingPlayers := make([]room.Player, 0, len(wsRoomState.clients))
-	for existingClient := range wsRoomState.clients {
-		if existingClient == client {
-			continue
-		}
-		existingPlayer, ok := wsRoomState.lobby.Player(existingClient.user.ID)
-		if ok {
-			existingPlayers = append(existingPlayers, existingPlayer)
-		}
-	}
-
 	broadcast := wsMessage{
 		Type:    messageTypePlayerJoined,
 		Payload: player,
@@ -109,7 +105,18 @@ func (h *wsHub) join(roomModel *models.Room, client *wsClient) ([]wsMessage, err
 
 	recipients := make([]*wsClient, 0, len(wsRoomState.clients))
 	for member := range wsRoomState.clients {
+		if member == client {
+			continue
+		}
 		recipients = append(recipients, member)
+	}
+
+	snapshot := wsMessage{
+		Type: messageTypeRoomState,
+		Payload: roomStatePayload{
+			RoomCode: roomModel.Code,
+			Players:  wsRoomState.lobby.Players(),
+		},
 	}
 
 	h.mu.Unlock()
@@ -118,15 +125,7 @@ func (h *wsHub) join(roomModel *models.Room, client *wsClient) ([]wsMessage, err
 		member.send <- broadcast
 	}
 
-	initialMessages := make([]wsMessage, 0, len(existingPlayers))
-	for _, existingPlayer := range existingPlayers {
-		initialMessages = append(initialMessages, wsMessage{
-			Type:    messageTypePlayerJoined,
-			Payload: existingPlayer,
-		})
-	}
-
-	return initialMessages, nil
+	return []wsMessage{snapshot}, nil
 }
 
 func (h *wsHub) leave(client *wsClient) {

--- a/backend/pkg/room/lobby.go
+++ b/backend/pkg/room/lobby.go
@@ -2,6 +2,7 @@ package room
 
 import (
 	"errors"
+	"slices"
 	"sync"
 )
 
@@ -107,6 +108,27 @@ func (l *Lobby) Players() []Player {
 	for _, player := range l.players {
 		players = append(players, player)
 	}
+	slices.SortFunc(players, func(a, b Player) int {
+		if a.IsHost != b.IsHost {
+			if a.IsHost {
+				return -1
+			}
+			return 1
+		}
+		if a.Username != b.Username {
+			if a.Username < b.Username {
+				return -1
+			}
+			return 1
+		}
+		if a.ID < b.ID {
+			return -1
+		}
+		if a.ID > b.ID {
+			return 1
+		}
+		return 0
+	})
 
 	return players
 }

--- a/backend/pkg/room/lobby.go
+++ b/backend/pkg/room/lobby.go
@@ -98,6 +98,19 @@ func (l *Lobby) Player(playerID uint) (Player, bool) {
 	return player, ok
 }
 
+// Players returns a snapshot of the current room roster.
+func (l *Lobby) Players() []Player {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	players := make([]Player, 0, len(l.players))
+	for _, player := range l.players {
+		players = append(players, player)
+	}
+
+	return players
+}
+
 // AllReady reports whether every tracked player is marked ready.
 func (l *Lobby) AllReady() bool {
 	l.mu.RLock()

--- a/backend/pkg/room/lobby_test.go
+++ b/backend/pkg/room/lobby_test.go
@@ -72,6 +72,34 @@ func TestLobbyJoinPlayerResetsReadyStateOnReconnect(t *testing.T) {
 	}
 }
 
+func TestLobbyPlayersReturnsDeterministicRosterOrder(t *testing.T) {
+	lobby := room.NewLobby()
+	lobby.JoinPlayer(room.Player{ID: 3, Username: "zoe"})
+	lobby.JoinPlayer(room.Player{ID: 1, Username: "host", IsHost: true})
+	lobby.JoinPlayer(room.Player{ID: 2, Username: "alice"})
+
+	players := lobby.Players()
+	if len(players) != 3 {
+		t.Fatalf("expected 3 players, got %d", len(players))
+	}
+
+	expected := []struct {
+		id       uint
+		username string
+		isHost   bool
+	}{
+		{id: 1, username: "host", isHost: true},
+		{id: 2, username: "alice", isHost: false},
+		{id: 3, username: "zoe", isHost: false},
+	}
+
+	for i, want := range expected {
+		if players[i].ID != want.id || players[i].Username != want.username || players[i].IsHost != want.isHost {
+			t.Fatalf("unexpected player at index %d: got %+v want id=%d username=%q isHost=%t", i, players[i], want.id, want.username, want.isHost)
+		}
+	}
+}
+
 func TestLobbyToggleReadyReturnsErrorForUnknownPlayer(t *testing.T) {
 	lobby := room.NewLobby()
 

--- a/frontend/src/app/pages/lobby/lobby.spec.ts
+++ b/frontend/src/app/pages/lobby/lobby.spec.ts
@@ -80,6 +80,17 @@ describe('Lobby', () => {
   });
 
   // --- PLAYER_JOINED ---
+  it('should replace the roster from ROOM_STATE', () => {
+    mockSocket.simulateOpen();
+    mockSocket.simulateMessage({
+      type: 'ROOM_STATE',
+      payload: { roomCode: 'AB12CD', players: [ALICE, BOB] },
+    });
+
+    expect(component.players.length).toBe(2);
+    expect(component.sortedPlayers[0].username).toBe('alice');
+  });
+
   it('should add a player on PLAYER_JOINED', () => {
     mockSocket.simulateOpen();
     mockSocket.simulateMessage({ type: 'PLAYER_JOINED', payload: BOB });

--- a/frontend/src/app/pages/lobby/lobby.ts
+++ b/frontend/src/app/pages/lobby/lobby.ts
@@ -8,6 +8,11 @@ import { uniqBy, orderBy } from 'lodash-es';
 import { WebSocketService } from '../../core/services/websocket.service';
 import { Player, WsMessage } from '../../core/models';
 
+interface RoomStatePayload {
+  roomCode: string;
+  players: Player[];
+}
+
 @Component({
   selector: 'app-lobby',
   standalone: true,
@@ -58,7 +63,11 @@ export class Lobby implements OnInit, OnDestroy {
   private handleMessage(msg: WsMessage): void {
     let playersChanged = false;
 
-    if (msg.type === 'PLAYER_JOINED') {
+    if (msg.type === 'ROOM_STATE') {
+      const payload = msg.payload as RoomStatePayload;
+      this.players = uniqBy(payload.players, 'id');
+      playersChanged = true;
+    } else if (msg.type === 'PLAYER_JOINED') {
       const player = msg.payload as Player;
       this.players = uniqBy([...this.players, player], 'id');
       playersChanged = true;


### PR DESCRIPTION
#18 
mplements issue #18 by adding room-scoped WebSocket lobby behavior for join/leave events.

What changed
Added room-based WebSocket membership tracking in the backend hub
Implemented JOIN_ROOM handling to attach a client to a specific room
Added ROOM_STATE snapshot response for the joining client
Broadcast PLAYER_JOINED only to the other clients in the same room
Added LEAVE_ROOM handling and disconnect cleanup
Broadcast PLAYER_LEFT to remaining room members when a client leaves
Added backend tests for:
room isolation
join broadcast behavior
explicit leave behavior
reconnect ready-state reset
Updated the frontend lobby to consume ROOM_STATE
Added changelog entry for issue #18
Why
This enables real-time lobby presence updates while keeping room traffic isolated, which is required before higher-level lobby features like ready state and room UI can build on top.

Verification
Passed: cd Backend && GOCACHE=/tmp/go-build go test ./pkg/api ./pkg/room
Notes
Frontend lobby tests were not run in this environment because node/npm were not available on PATH.